### PR TITLE
set existing member status to online

### DIFF
--- a/src/library/binlog/binlog.go
+++ b/src/library/binlog/binlog.go
@@ -145,6 +145,7 @@ func (h *Binlog) setMember(dns string, isLeader bool, index int) int {
 	if ok {
 		mem.isLeader = isLeader
 		mem.index = index
+		mem.status = MEMBER_STATUS_LIVE
 	} else {
 		h.members[dns] = &member{
 			isLeader: isLeader,


### PR DESCRIPTION
if a node rejoin the cluster, the status might incorrect.